### PR TITLE
BUG: Add missing run export

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: 047b8229511a82b5718a1d34c86c067b078efd02f602986d2ed09b23182ec136
 
 build:
-  number: 0
+  number: 1
   script:
     - set -ex
     - >
@@ -24,6 +24,8 @@ build:
         --buildtype=release -Denable_tests=false
     - meson compile -C _build
     - meson install -C _build --no-rebuild
+  run_exports:
+    - {{ pin_subpackage( name|lower, max_pin='x.x.x') }}
 
 requirements:
   build:


### PR DESCRIPTION
No documented ABI/API correlation guarantees upstream that I could find, so pinning to patch is conservative.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
